### PR TITLE
Automatically launch with GDK_SCALE for HiDPI support

### DIFF
--- a/josm.sh
+++ b/josm.sh
@@ -1,3 +1,18 @@
 #!/bin/sh
 
+# Java2D and Swing APIs use Xlib and support HiDPI via GDK_SCALE var
+# http://hg.openjdk.java.net/jdk9/jdk9/jdk/rev/bc2d1130105f#l27.8
+GDK_SCALE=1
+is_natural_number='^[0-9]+$'
+DPI=`xgetres Xft.dpi`
+# if $DPI is a natural number, taken from https://stackoverflow.com/a/806923
+if [[ $DPI =~ $is_natural_number ]] ; then
+   # float division in bash, taken from https://stackoverflow.com/a/21032001
+   SCALE=`echo "$DPI 96" | awk '{printf "%.1f \n", $1/$2}'`
+   # Round in bash, taken from https://stackoverflow.com/a/26465573
+   GDK_SCALE=$(LC_ALL=C printf "%.0f\n" $SCALE)
+fi
+
+export GDK_SCALE
+
 java -jar /app/bin/josm.jar

--- a/org.openstreetmap.josm.yaml
+++ b/org.openstreetmap.josm.yaml
@@ -18,6 +18,16 @@ build-options:
   env:
     JAVA_HOME: /usr/lib/sdk/openjdk11/
 modules:
+  - name: xgetres
+    buildsystem: simple
+    build-commands:
+      - make
+      - make install PREFIX=/app
+    sources:
+      - type: git
+        url: https://github.com/tamirzb/xgetres
+        commit: 7dd6aa2e3a469382ba09152710a5bb4abb3fbc9c
+
   - name: openjdk
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
Similar to other Java apps in flathub[1], use the `xgetres`
binary to automatically retrieve current DPI of our X session
and so launch the java command with a proper GDK_SCALE value.

[1] like these:
com.github.mgropp.PdfJumbler
com.itextpdf.RUPS
net.sourceforge.pdfchain
io.sourceforge.Pixelitor
com.diy_fever.DIYLayoutCreator
org.verapdf.veraPDF