### PR TITLE
Update org.openstreetmap.josm.desktop

### DIFF
--- a/org.openstreetmap.josm.yaml
+++ b/org.openstreetmap.josm.yaml
@@ -52,8 +52,8 @@ modules:
         sha256: 2a12b004d0711bbc9052a11ddfa44dfb3417068ef451714b7728c155fd854457
 
       - type: file
-        url: https://josm.openstreetmap.de/export/17428/josm/trunk/native/linux/tested/usr/share/applications/org.openstreetmap.josm.desktop
-        sha256: 8c1c5f615c361d3ab565ec740c6a1cee9d5d5804d764d700b18c1a46311f851a
+        url: https://josm.openstreetmap.de/export/18402/josm/trunk/native/linux/tested/usr/share/applications/org.openstreetmap.josm.desktop
+        sha256: e3da3e4075f9ca804cd1f7c077a60689016247d4de64d0b046311a537c24e51a
 
       - type: file
         url: https://josm.openstreetmap.de/export/18454/josm/trunk/native/linux/tested/usr/bin/josm


### PR DESCRIPTION
See JOSM [r18226](https://josm.openstreetmap.de/changeset/18226/josm/), [r18235](https://josm.openstreetmap.de/changeset/18235/josm/), [r18304](https://josm.openstreetmap.de/changeset/18304/josm/), and [r18402](https://josm.openstreetmap.de/changeset/18402/josm/) for more information.

Key changes:
* Associate the following mime types:
  * application/gpx+xml
  * application/zip
  * Use osm.&lt;compression&gt; for file extensions
* Fix StartupWMClass (was missing `-gui` part of the package for
  `MainApplication`)

Signed-off-by: Taylor Smock <tsmock@fb.com>