### PR TITLE
Fix Github #55: /usr/lib/jvm/default-java/bin/java does not exist

### DIFF
--- a/josm.patch
+++ b/josm.patch
@@ -17,14 +17,17 @@
  if dpkg --get-selections "openjdk-*-jre" | grep install$ > /dev/null \
  || dpkg --get-selections "openjdk-*-jre:$ARCH" | grep install$ > /dev/null ; then
  	# LTS versions in decreased order
-@@ -29,6 +30,7 @@
+@@ -29,8 +30,9 @@
  	# Development version(s)
  	JAVA_CMDS="${JAVA_CMDS} /usr/lib/jvm/java-18-openjdk/bin/java /usr/lib/jvm/java-18-openjdk-$ARCH/bin/java"
  fi
 +fi
  # Undetermined version
- JAVA_CMDS="${JAVA_CMDS} /usr/lib/jvm/default-java/bin/java /usr/bin/java"
+-JAVA_CMDS="${JAVA_CMDS} /usr/lib/jvm/default-java/bin/java /usr/bin/java"
++JAVA_CMDS="${JAVA_CMDS} /usr/bin/java"
  
+ if [ -f /etc/default/josm ]; then
+     . /etc/default/josm
 @@ -56,6 +58,23 @@
      done
  fi
@@ -59,4 +62,3 @@
          if [ "z$?" != "z9" ]; then
              break
          fi
-


### PR DESCRIPTION
This is due to an upstream bug whereby non-existent paths are not
removed from java binary path candidates.

Signed-off-by: Taylor Smock <tsmock@fb.com>