### PR TITLE
Update runtime to 22.08

### DIFF
--- a/org.openstreetmap.josm.yaml
+++ b/org.openstreetmap.josm.yaml
@@ -1,6 +1,6 @@
 app-id: org.openstreetmap.josm
 runtime: org.freedesktop.Platform
-runtime-version: '21.08'
+runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.openjdk17


### PR DESCRIPTION
Tested that basic functionality continues to work: fetching data, uploading changesets, pulling imagery.