### PR TITLE
Use rolling Java release until next LTS

### DIFF
--- a/org.openstreetmap.josm.yaml
+++ b/org.openstreetmap.josm.yaml
@@ -3,7 +3,7 @@ runtime: org.freedesktop.Platform
 runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.openjdk17
+  - org.freedesktop.Sdk.Extension.openjdk
 command: josm
 rename-icon: josm
 finish-args:
@@ -18,7 +18,7 @@ finish-args:
 
 build-options:
   env:
-    JAVA_HOME: /usr/lib/sdk/openjdk17/
+    JAVA_HOME: /usr/lib/sdk/openjdk/
 modules:
   - name: xgetres
     buildsystem: simple
@@ -33,7 +33,7 @@ modules:
   - name: openjdk
     buildsystem: simple
     build-commands:
-      - /usr/lib/sdk/openjdk17/install.sh
+      - /usr/lib/sdk/openjdk/install.sh
 
   - name: openjfx
     buildsystem: simple


### PR DESCRIPTION
This should fix https://josm.openstreetmap.de/ticket/14596 for the flatpak.

Note: I haven't run this yet. It should work, but I do want to verify.